### PR TITLE
Make sspmod_hexaa_Auth_Process_Hexaa chainable

### DIFF
--- a/lib/Auth/Process/Hexaa.php
+++ b/lib/Auth/Process/Hexaa.php
@@ -40,6 +40,11 @@ class sspmod_hexaa_Auth_Process_Hexaa extends SimpleSAML_Auth_ProcessingFilter
         $nameId = $state['Attributes'][$this->as_config['nameId_attribute_name']][0];
         $spid = $state['Destination']['entityid'];
         $state['Attributes'] = $this->getAttributes($nameId, $spid);
+
+        // restore the nameId_attribute_name attribute in the state array because the $this->getAttributes(...) call destroys it
+        if (empty($state['Attributes'][$this->as_config['nameId_attribute_name']])) {
+            $state['Attributes'][$this->as_config['nameId_attribute_name']] = $nameId;
+        }
     }
     
     public function getAttributes($nameId, $spid, $attributes = array()) {


### PR DESCRIPTION
Restore the nameId_attribute_name attribute to the Attributes array to allow sspmod_hexaa_Auth_Process_Hexaa to be chained with other AA backends like VOPaaS. This works provided HEXAA is first in the chain.